### PR TITLE
Optimize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
+Country.mmdb
 RealiTLScanner
 RealiTLScanner.exe
-results.txt
 .idea
-in.txt
-out.txt
-out.csv
-Country.mmdb
+
+# All CSV and TXT files
+*.csv
+*.txt


### PR DESCRIPTION
In the origin `.gitignore` file only ignores **specific txt and csv files**. But I think it's better to ignore **all txt and csv files**

## Reasons

End users will most likely put content in a txt file, which will be named to other names instead of `in.txt` like `DMIT(LAX).txt`, `AWS(JP).txt` and so on. So as to the csv files, they will specify other names to distinguish instead of `out.csv` or `out.txt` or `results.txt`