### PR TITLE
fix: nil pointer dereference in ScanTLS when no cert has DNSNames

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"log/slog"
 	"net"
 	"strconv"
@@ -50,7 +49,7 @@ func ScanTLS(host Host, out chan<- string, geo *Geo) {
 	domain := state.PeerCertificates[0].Subject.CommonName
 	issuers := strings.Join(state.PeerCertificates[0].Issuer.Organization, " | ")
 	length := 0
-	var leaf *x509.Certificate
+	leaf := state.PeerCertificates[0]
 	for _, cert := range state.PeerCertificates {
 		length += len(cert.Raw)
 		if len(cert.DNSNames) != 0 {


### PR DESCRIPTION
Fixes #39 

**PROBLEM** 
ScanTLS panics with a `nil` pointer dereference when none of the peer certificates contain DNSNames (e.g. certificates that only use `Subject.CommonName`).

```
panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x2 addr=0x90 pc=0x102cd96f0]

  goroutine 11 [running]:
  main.ScanTLS(...)
          scanner.go:76
```

**ROOT CAUSE** 
leaf was declared as `var leaf *x509.Certificate` and only assigned inside the loop if a certificate had DNSNames. If no such certificate existed, `leaf` remained `nil`. It was then unconditionally dereferenced in the slog call at the end of the function, even for non-feasible hosts.

 **FIX**
Initialize `leaf` to the first certificate before the loop and override it with the first certificate that has DNSNames if one is found.