### PR TITLE
fix: update Go version in Dockerfile from 1.22 to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY . .
 RUN go build -o RealiTLScanner .


### PR DESCRIPTION
Fixes #37 

**PROBLEM**
Building the Docker image fails because go.mod requires Go 1.26, but the Dockerfile uses golang:1.22-alpine:

```
 => [build 3/4] COPY . .                                                                                                                                                                                                             0.1s
 => ERROR [build 4/4] RUN go build -o RealiTLScanner .                                                                                                                                                                                    0.2s
------
 > [build 4/4] RUN go build -o RealiTLScanner .:
0.137 go: go.mod requires go >= 1.26 (running go 1.22.12; GOTOOLCHAIN=local)
------
Dockerfile:4
--------------------
   2 |     WORKDIR /src
   3 |     COPY . .
   4 | >>> RUN go build -o RealiTLScanner .
   5 |
   6 |     FROM alpine:latest
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go build -o RealiTLScanner ." did not complete successfully: exit code: 1

```
**FIX**
Update the base image in Dockerfile to match the version required by go.mod