### PR TITLE
Add optional DNS validation to filter out fake SNI targets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require github.com/oschwald/geoip2-golang v1.13.0
 
 require (
 	github.com/oschwald/maxminddb-golang v1.13.1 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -22,6 +22,9 @@ var verbose bool
 var enableIPv6 bool
 var url string
 
+var resolveDomains bool
+
+
 func main() {
 	_ = os.Unsetenv("ALL_PROXY")
 	_ = os.Unsetenv("HTTP_PROXY")
@@ -38,6 +41,7 @@ func main() {
 	flag.BoolVar(&enableIPv6, "46", false, "Enable IPv6 in additional to IPv4")
 	flag.StringVar(&url, "url", "", "Crawl the domain list from a URL, "+
 		"e.g. https://launchpad.net/ubuntu/+archivemirrors")
+	flag.BoolVar(&resolveDomains, "resolve-domains", false, "DNS-resolve the domain from the TLS certificate and verify if the scanned IP is among the A/AAAA records")
 	flag.Parse()
 	if verbose {
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/scanner.go
+++ b/scanner.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"log/slog"
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
+
+// dnsCache stores only successful resolutions.
+var dnsCache = make(map[string][]net.IP)
+var dnsCacheMu sync.RWMutex
+var dnsSF singleflight.Group
+
 
 func ScanTLS(host Host, out chan<- string, geo *Geo) {
 	if host.IP == nil {
@@ -46,7 +56,13 @@ func ScanTLS(host Host, out chan<- string, geo *Geo) {
 	}
 	state := c.ConnectionState()
 	alpn := state.NegotiatedProtocol
-	domain := state.PeerCertificates[0].Subject.CommonName
+	domain := ""
+	if len(state.PeerCertificates[0].DNSNames) > 0 {
+		domain = state.PeerCertificates[0].DNSNames[0]
+	} else {
+		domain = state.PeerCertificates[0].Subject.CommonName
+	}
+
 	issuers := strings.Join(state.PeerCertificates[0].Issuer.Organization, " | ")
 	length := 0
 	leaf := state.PeerCertificates[0]
@@ -57,13 +73,64 @@ func ScanTLS(host Host, out chan<- string, geo *Geo) {
 		}
 	}
 
-	log := slog.Info
 	feasible := true
 	geoCode := geo.GetGeo(host.IP)
 	if state.Version != tls.VersionTLS13 || alpn != "h2" || len(domain) == 0 || len(issuers) == 0 {
 		// not feasible
-		log = slog.Debug
 		feasible = false
+	}
+
+	if feasible && resolveDomains {
+		lookupDomain := domain
+		if strings.HasPrefix(lookupDomain, "*.") {
+			lookupDomain = lookupDomain[2:]
+		}
+
+		dnsCacheMu.RLock()
+		resolvedIPs, cached := dnsCache[lookupDomain]
+		dnsCacheMu.RUnlock()
+
+		if !cached {
+			v, err, _ := dnsSF.Do(lookupDomain, func() (interface{}, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+				defer cancel()
+				addrs, err := net.DefaultResolver.LookupIPAddr(ctx, lookupDomain)
+				if err != nil {
+					return ([]net.IP)(nil), err
+				}
+				ips := make([]net.IP, len(addrs))
+				for i, a := range addrs {
+					ips[i] = a.IP
+				}
+				dnsCacheMu.Lock()
+				dnsCache[lookupDomain] = ips
+				dnsCacheMu.Unlock()
+				return ips, nil
+			})
+			if err != nil {
+				slog.Debug("DNS resolution failed", "domain", lookupDomain, "err", err)
+				resolvedIPs = nil
+			} else {
+				resolvedIPs = v.([]net.IP)
+			}
+		}
+
+		ipMatched := false
+		for _, rip := range resolvedIPs {
+			if rip.Equal(host.IP) {
+				ipMatched = true
+				break
+			}
+		}
+		if !ipMatched {
+			slog.Debug("IP mismatch with cert domain DNS records", "ip", host.IP.String(), "domain", lookupDomain)
+			feasible = false
+		}
+	}
+
+	log := slog.Info
+	if !feasible {
+		log = slog.Debug
 	} else {
 		out <- strings.Join([]string{
 			host.IP.String(), 


### PR DESCRIPTION
# Add optional DNS validation to filter out fake SNI targets

> [!NOTE]
> * This PR is a redesigned and fully explained version of the closed #27.
> * It directly addresses and implements the features requested by the community in **#21** (DNS resolution of cert-domains) and **#34** (skipping other Reality servers via DNS probing).

### Problem & Background

`RealiTLScanner` is used to find suitable destination (`dest`) and SNI (`serverNames`) pairs for VLESS Reality. The goal is to find legitimate websites hosted on the same hosting provider/subnet as the user's VPS to masquerade under them.

**Why this feature is needed now:**
* **Shifting to smaller hosters:** In censored environments (like Russia with their TSPU DPI system), large hosting providers such as Hetzner or OVH suffer from severe traffic filtering and connection degradation (e.g., the 16KB connection limit). This forces users to deploy their VPS on smaller, budget, or less popular ASNs.
* **Subnets flooded with fake SNIs:** When scanning these smaller VPS subnets, the scanner returns dozens of "feasible" targets presenting certificates for popular domains (like `google.com`, `apple.com`, `yahoo.com`, `vk.com`).
* **Existing Reality servers as false positives:** Since these large companies do not host their infrastructure on cheap VPS providers, these IPs are actually **<ins>other users existing VLESS + Reality servers</ins>** masquerading under stolen/cloned certificates. When `RealiTLScanner` handshakes with them, it receives a forwarded handshake, tricking the scanner into returning them as valid destinations.  *(This behavior and the need to filter them has been highlighted by users in **#21** and **#34**).*


### Addressing the doubts in #27

In #27, the question was raised:
> *Even if the IP doesn't match the DNS record, you can still use it as a fallback target. What is the practical benefit of filtering this?*

While connecting to such a target technically "works" (the handshake succeeds), using them as a Reality destination is highly counterproductive and currently **dangerous for the entire hoster**, for the following reasons:

1. **Eliminating False Positives (Unstable Targets):** Returning other people's temporary proxies defeats the purpose of the scanner. The goal is to find stable, legitimate, local websites, not "nested" proxy servers that can be reconfigured or shut down by their owners at any moment.
2. **Active DPI Triggers (The SNI Marker Issue):** Using popular domains (`google.com`, `icloud.com`, etc.) on a cheap VPS IP is no longer just an "anomaly" — **it is a <ins>known circumvention marker for DPI systems</ins> (like TSPU).** Censors now actively identify VLESS+Reality specifically by checking these "exposed" popular SNIs mismatching their ASNs. 
3. **Subnet-wide Bans & TOS Violations:** DPI systems often respond to these glaring anomalies not by blocking a single IP, but by **<ins>blocking the entire /24 subnet</ins>**. Because of this, hosting providers have started sending TOS Violation notices and suspending accounts of users who use large public domains for SNI masking, as one user's configuration ruins network accessibility for the entire subnet. 

Filtering out these fake targets is now a necessity for <ins>stealth and server survival</ins>.


### The Solution

This PR adds a `-resolve-domains` flag (**disabled by default**). 

When enabled, the scanner:
1. Extracts the certificate domain name (preferring `DNSNames[0]`, falling back to `Subject.CommonName`).
2. DNS-resolves the domain to its actual `A`/`AAAA` records.
3. Discards the target if the scanned IP is not present in those records.


### Implementation Details

* **Caching:** DNS resolutions are cached thread-safely using `sync.RWMutex`. Only successful resolutions are stored to prevent permanent domain filtering caused by temporary network timeouts.
* **Resolver Protection:** We use `golang.org/x/sync/singleflight` to prevent duplicate concurrent DNS requests for the same domain, protecting the local resolver from overload during high-thread scans.